### PR TITLE
Fix husky setup affecting installs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,6 @@
   "packages": {
     "": {
       "version": "1.4.0",
-      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@typescript-eslint/eslint-plugin": "^4.0.0"

--- a/package.json
+++ b/package.json
@@ -5,10 +5,9 @@
   "main": "lib/index.js",
   "scripts": {
     "build": "rm -rf ./lib && tsc",
-    "prepare": "npm run test && npm run lint && npm run build",
+    "prepare": "is-ci || husky install && npm run test && npm run lint && npm run build",
     "test": "jest --coverage",
-    "lint": "eslint ./src --ext .ts,.tsx",
-    "postinstall": "is-ci || husky install"
+    "lint": "eslint ./src --ext .ts,.tsx"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Postinstall runs when consumers run npm install as well, which is only meant for development.