### PR TITLE
fix(pkg): correct compiled output paths and remove src from published files

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "react-three-state-checkbox",
   "version": "4.0.0",
   "description": "React component for checkbox that supports the indeterminate state conveniently.",
-  "main": "lib/src/index.js",
-  "types": "lib/src/index.d.ts",
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "sideEffects": false,
   "scripts": {
     "build": "rm -rf ./lib && tsc",
@@ -32,7 +32,7 @@
     "node": ">=22"
   },
   "files": [
-    "lib/src",
+    "lib",
     "src",
     "LICENSE"
   ],

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
   },
   "files": [
     "lib",
-    "src",
     "LICENSE"
   ],
   "devDependencies": {


### PR DESCRIPTION
## Summary
- Corrected compiled output paths for npm publish so consumers get the right dist files
- Removed `src` directory from published files to keep package lean and avoid shipping raw TypeScript source

## Test plan
- [ ] `npm pack` and inspect tarball — only `dist/` and package metadata present, no `src/`
- [ ] Install packed tarball in a test project and verify import resolves correctly
- [ ] Check `package.json` `main`/`module`/`types` fields point to valid paths in `dist/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)