### PR TITLE
chore(deps): upgrade @jchiam/eslint-config to ^5.1.1

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -7,7 +7,7 @@ export default [
   ...react,
   {
     rules: {
-      'react/react-in-jsx-scope': 'off',
+      '@eslint-react/no-forward-ref': 'off',
     },
   },
 ];

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,13 +9,12 @@
       "version": "4.0.1",
       "license": "MIT",
       "devDependencies": {
-        "@jchiam/eslint-config": "^5.0.2",
+        "@jchiam/eslint-config": "^5.1.1",
         "@playwright/experimental-ct-react": "^1.59.1",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
         "eslint": "^9.39.4",
         "eslint-plugin-import": "^2.32.0",
-        "eslint-plugin-react": "^7.37.5",
         "eslint-plugin-react-hooks": "^7.0.0",
         "husky": "^9.1.7",
         "is-ci": "^4.1.0",
@@ -872,6 +871,109 @@
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
       }
     },
+    "node_modules/@eslint-react/ast": {
+      "version": "1.53.1",
+      "resolved": "https://registry.npmjs.org/@eslint-react/ast/-/ast-1.53.1.tgz",
+      "integrity": "sha512-qvUC99ewtriJp9quVEOvZ6+RHcsMLfVQ0OhZ4/LupZUDhjW7GiX1dxJsFaxHdJ9rLNLhQyLSPmbAToeqUrSruQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-react/eff": "1.53.1",
+        "@typescript-eslint/types": "^8.43.0",
+        "@typescript-eslint/typescript-estree": "^8.43.0",
+        "@typescript-eslint/utils": "^8.43.0",
+        "string-ts": "^2.2.1",
+        "ts-pattern": "^5.8.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@eslint-react/core": {
+      "version": "1.53.1",
+      "resolved": "https://registry.npmjs.org/@eslint-react/core/-/core-1.53.1.tgz",
+      "integrity": "sha512-8prroos5/Uvvh8Tjl1HHCpq4HWD3hV9tYkm7uXgKA6kqj0jHlgRcQzuO6ZPP7feBcK3uOeug7xrq03BuG8QKCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-react/ast": "1.53.1",
+        "@eslint-react/eff": "1.53.1",
+        "@eslint-react/kit": "1.53.1",
+        "@eslint-react/shared": "1.53.1",
+        "@eslint-react/var": "1.53.1",
+        "@typescript-eslint/scope-manager": "^8.43.0",
+        "@typescript-eslint/type-utils": "^8.43.0",
+        "@typescript-eslint/types": "^8.43.0",
+        "@typescript-eslint/utils": "^8.43.0",
+        "birecord": "^0.1.1",
+        "ts-pattern": "^5.8.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@eslint-react/eff": {
+      "version": "1.53.1",
+      "resolved": "https://registry.npmjs.org/@eslint-react/eff/-/eff-1.53.1.tgz",
+      "integrity": "sha512-uq20lPRAmsWRjIZm+mAV/2kZsU2nDqn5IJslxGWe3Vfdw23hoyhEw3S1KKlxbftwbTvsZjKvVP0iw3bZo/NUpg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@eslint-react/kit": {
+      "version": "1.53.1",
+      "resolved": "https://registry.npmjs.org/@eslint-react/kit/-/kit-1.53.1.tgz",
+      "integrity": "sha512-zOi2le9V4rMrJvQV4OeedGvMGvDT46OyFPOwXKs7m0tQu5vXVJ8qwIPaVQT1n/WIuvOg49OfmAVaHpGxK++xLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-react/eff": "1.53.1",
+        "@typescript-eslint/utils": "^8.43.0",
+        "ts-pattern": "^5.8.0",
+        "zod": "^4.1.5"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@eslint-react/shared": {
+      "version": "1.53.1",
+      "resolved": "https://registry.npmjs.org/@eslint-react/shared/-/shared-1.53.1.tgz",
+      "integrity": "sha512-gomJQmFqQgQVI3Ra4vTMG/s6a4bx3JqeNiTBjxBJt4C9iGaBj458GkP4LJHX7TM6xUzX+fMSKOPX7eV3C/+UCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-react/eff": "1.53.1",
+        "@eslint-react/kit": "1.53.1",
+        "@typescript-eslint/utils": "^8.43.0",
+        "ts-pattern": "^5.8.0",
+        "zod": "^4.1.5"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@eslint-react/var": {
+      "version": "1.53.1",
+      "resolved": "https://registry.npmjs.org/@eslint-react/var/-/var-1.53.1.tgz",
+      "integrity": "sha512-yzwopvPntcHU7mmDvWzRo1fb8QhjD8eDRRohD11rTV1u7nWO4QbJi0pOyugQakvte1/W11Y0Vr8Of0Ojk/A6zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-react/ast": "1.53.1",
+        "@eslint-react/eff": "1.53.1",
+        "@typescript-eslint/scope-manager": "^8.43.0",
+        "@typescript-eslint/types": "^8.43.0",
+        "@typescript-eslint/utils": "^8.43.0",
+        "string-ts": "^2.2.1",
+        "ts-pattern": "^5.8.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
     "node_modules/@eslint/config-array": {
       "version": "0.21.2",
       "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
@@ -1090,20 +1192,20 @@
       }
     },
     "node_modules/@jchiam/eslint-config": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@jchiam/eslint-config/-/eslint-config-5.0.2.tgz",
-      "integrity": "sha512-sMcpGOwJTC3dyDMJhBrs7sPcwv2EMmZ/qxASO5ZH5QRQ+xq62TIxG2/kq5Z8v46H2FUoAGn+KdrLk2cr6v49YA==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@jchiam/eslint-config/-/eslint-config-5.1.1.tgz",
+      "integrity": "sha512-kph4olazeWKVE4vht7cMdKiSzJ5Lx8aGgPbJxmji6uTZ/zcBPWH6pPIU1KJ0VCw061gpydc8t24xKHW0f1O47g==",
       "dev": true,
       "dependencies": {
+        "@eslint-react/eslint-plugin": "^1.0.0",
         "@eslint/js": "^9.0.0",
         "@stylistic/eslint-plugin": "^5.0.0",
-        "globals": "^17.0.0"
+        "globals": "^17.6.0"
       },
       "peerDependencies": {
         "eslint": "^9.0.0 || ^10.0.0",
         "eslint-plugin-import": "^2.29.0",
         "eslint-plugin-jest": "^29.0.0",
-        "eslint-plugin-react": "^7.32.0",
         "eslint-plugin-react-hooks": "^7.0.0",
         "typescript-eslint": "^8.0.0"
       },
@@ -1111,10 +1213,265 @@
         "eslint-plugin-jest": {
           "optional": true
         },
-        "eslint-plugin-react": {
+        "eslint-plugin-react-hooks": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@jchiam/eslint-config/node_modules/@eslint-react/eslint-plugin": {
+      "version": "1.53.1",
+      "resolved": "https://registry.npmjs.org/@eslint-react/eslint-plugin/-/eslint-plugin-1.53.1.tgz",
+      "integrity": "sha512-JZ2ciXNCC9CtBBAqYtwWH+Jy/7ZzLw+whei8atP4Fxsbh+Scs30MfEwBzuiEbNw6uF9eZFfPidchpr5RaEhqxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-react/eff": "1.53.1",
+        "@eslint-react/kit": "1.53.1",
+        "@eslint-react/shared": "1.53.1",
+        "@typescript-eslint/scope-manager": "^8.43.0",
+        "@typescript-eslint/type-utils": "^8.43.0",
+        "@typescript-eslint/types": "^8.43.0",
+        "@typescript-eslint/utils": "^8.43.0",
+        "eslint-plugin-react-debug": "1.53.1",
+        "eslint-plugin-react-dom": "1.53.1",
+        "eslint-plugin-react-hooks-extra": "1.53.1",
+        "eslint-plugin-react-naming-convention": "1.53.1",
+        "eslint-plugin-react-web-api": "1.53.1",
+        "eslint-plugin-react-x": "1.53.1"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": "^4.9.5 || ^5.3.3"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": false
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@jchiam/eslint-config/node_modules/eslint-plugin-react-debug": {
+      "version": "1.53.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-debug/-/eslint-plugin-react-debug-1.53.1.tgz",
+      "integrity": "sha512-WNOiQ6jhodJE88VjBU/IVDM+2Zr9gKHlBFDUSA3fQ0dMB5RiBVj5wMtxbxRuipK/GqNJbteqHcZoYEod7nfddg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-react/ast": "1.53.1",
+        "@eslint-react/core": "1.53.1",
+        "@eslint-react/eff": "1.53.1",
+        "@eslint-react/kit": "1.53.1",
+        "@eslint-react/shared": "1.53.1",
+        "@eslint-react/var": "1.53.1",
+        "@typescript-eslint/scope-manager": "^8.43.0",
+        "@typescript-eslint/type-utils": "^8.43.0",
+        "@typescript-eslint/types": "^8.43.0",
+        "@typescript-eslint/utils": "^8.43.0",
+        "string-ts": "^2.2.1",
+        "ts-pattern": "^5.8.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": "^4.9.5 || ^5.3.3"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": false
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@jchiam/eslint-config/node_modules/eslint-plugin-react-dom": {
+      "version": "1.53.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-dom/-/eslint-plugin-react-dom-1.53.1.tgz",
+      "integrity": "sha512-UYrWJ2cS4HpJ1A5XBuf1HfMpPoLdfGil+27g/ldXfGemb4IXqlxHt4ANLyC8l2CWcE3SXGJW7mTslL34MG0qTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-react/ast": "1.53.1",
+        "@eslint-react/core": "1.53.1",
+        "@eslint-react/eff": "1.53.1",
+        "@eslint-react/kit": "1.53.1",
+        "@eslint-react/shared": "1.53.1",
+        "@eslint-react/var": "1.53.1",
+        "@typescript-eslint/scope-manager": "^8.43.0",
+        "@typescript-eslint/types": "^8.43.0",
+        "@typescript-eslint/utils": "^8.43.0",
+        "compare-versions": "^6.1.1",
+        "string-ts": "^2.2.1",
+        "ts-pattern": "^5.8.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": "^4.9.5 || ^5.3.3"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": false
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@jchiam/eslint-config/node_modules/eslint-plugin-react-hooks-extra": {
+      "version": "1.53.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks-extra/-/eslint-plugin-react-hooks-extra-1.53.1.tgz",
+      "integrity": "sha512-fshTnMWNn9NjFLIuy7HzkRgGK29vKv4ZBO9UMr+kltVAfKLMeXXP6021qVKk66i/XhQjbktiS+vQsu1Rd3ZKvg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-react/ast": "1.53.1",
+        "@eslint-react/core": "1.53.1",
+        "@eslint-react/eff": "1.53.1",
+        "@eslint-react/kit": "1.53.1",
+        "@eslint-react/shared": "1.53.1",
+        "@eslint-react/var": "1.53.1",
+        "@typescript-eslint/scope-manager": "^8.43.0",
+        "@typescript-eslint/type-utils": "^8.43.0",
+        "@typescript-eslint/types": "^8.43.0",
+        "@typescript-eslint/utils": "^8.43.0",
+        "string-ts": "^2.2.1",
+        "ts-pattern": "^5.8.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": "^4.9.5 || ^5.3.3"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": false
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@jchiam/eslint-config/node_modules/eslint-plugin-react-naming-convention": {
+      "version": "1.53.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-naming-convention/-/eslint-plugin-react-naming-convention-1.53.1.tgz",
+      "integrity": "sha512-rvZ/B/CSVF8d34HQ4qIt90LRuxotVx+KUf3i1OMXAyhsagEFMRe4gAlPJiRufZ+h9lnuu279bEdd+NINsXOteA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-react/ast": "1.53.1",
+        "@eslint-react/core": "1.53.1",
+        "@eslint-react/eff": "1.53.1",
+        "@eslint-react/kit": "1.53.1",
+        "@eslint-react/shared": "1.53.1",
+        "@eslint-react/var": "1.53.1",
+        "@typescript-eslint/scope-manager": "^8.43.0",
+        "@typescript-eslint/type-utils": "^8.43.0",
+        "@typescript-eslint/types": "^8.43.0",
+        "@typescript-eslint/utils": "^8.43.0",
+        "string-ts": "^2.2.1",
+        "ts-pattern": "^5.8.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": "^4.9.5 || ^5.3.3"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": false
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@jchiam/eslint-config/node_modules/eslint-plugin-react-web-api": {
+      "version": "1.53.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-web-api/-/eslint-plugin-react-web-api-1.53.1.tgz",
+      "integrity": "sha512-INVZ3Cbl9/b+sizyb43ChzEPXXYuDsBGU9BIg7OVTNPyDPloCXdI+dQFAcSlDocZhPrLxhPV3eT6+gXbygzYXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-react/ast": "1.53.1",
+        "@eslint-react/core": "1.53.1",
+        "@eslint-react/eff": "1.53.1",
+        "@eslint-react/kit": "1.53.1",
+        "@eslint-react/shared": "1.53.1",
+        "@eslint-react/var": "1.53.1",
+        "@typescript-eslint/scope-manager": "^8.43.0",
+        "@typescript-eslint/types": "^8.43.0",
+        "@typescript-eslint/utils": "^8.43.0",
+        "string-ts": "^2.2.1",
+        "ts-pattern": "^5.8.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": "^4.9.5 || ^5.3.3"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": false
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@jchiam/eslint-config/node_modules/eslint-plugin-react-x": {
+      "version": "1.53.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-x/-/eslint-plugin-react-x-1.53.1.tgz",
+      "integrity": "sha512-MwMNnVwiPem0U6SlejDF/ddA4h/lmP6imL1RDZ2m3pUBrcdcOwOx0gyiRVTA3ENnhRlWfHljHf5y7m8qDSxMEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-react/ast": "1.53.1",
+        "@eslint-react/core": "1.53.1",
+        "@eslint-react/eff": "1.53.1",
+        "@eslint-react/kit": "1.53.1",
+        "@eslint-react/shared": "1.53.1",
+        "@eslint-react/var": "1.53.1",
+        "@typescript-eslint/scope-manager": "^8.43.0",
+        "@typescript-eslint/type-utils": "^8.43.0",
+        "@typescript-eslint/types": "^8.43.0",
+        "@typescript-eslint/utils": "^8.43.0",
+        "compare-versions": "^6.1.1",
+        "is-immutable-type": "^5.0.1",
+        "string-ts": "^2.2.1",
+        "ts-pattern": "^5.8.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0",
+        "ts-api-utils": "^2.1.0",
+        "typescript": "^4.9.5 || ^5.3.3"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": false
+        },
+        "ts-api-utils": {
           "optional": true
         },
-        "eslint-plugin-react-hooks": {
+        "typescript": {
           "optional": true
         }
       }
@@ -2966,26 +3323,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/array.prototype.findlast": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/array.prototype.findlast/-/array.prototype.findlast-1.2.5.tgz",
-      "integrity": "sha512-CVvd6FHg1Z3POpBLxO6E6zr+rSKEQ9L6rZHAaY7lLfhKsWYUBBOuMs0e9o24oopj6H+geRCX0YJ+TJLBK2eHyQ==",
-      "dev": true,
-      "dependencies": {
-        "call-bind": "^1.0.7",
-        "define-properties": "^1.2.1",
-        "es-abstract": "^1.23.2",
-        "es-errors": "^1.3.0",
-        "es-object-atoms": "^1.0.0",
-        "es-shim-unscopables": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/array.prototype.findlastindex": {
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/array.prototype.findlastindex/-/array.prototype.findlastindex-1.2.6.tgz",
@@ -3044,22 +3381,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/array.prototype.tosorted": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/array.prototype.tosorted/-/array.prototype.tosorted-1.1.4.tgz",
-      "integrity": "sha512-p6Fx8B7b7ZhL/gmUsAy0D15WhvDccw3mnGNbZpi3pmeJdxtWsj2jEaI4Y6oo3XiHfzuSgPwKc04MYt6KgvC/wA==",
-      "dev": true,
-      "dependencies": {
-        "call-bind": "^1.0.7",
-        "define-properties": "^1.2.1",
-        "es-abstract": "^1.23.3",
-        "es-errors": "^1.3.0",
-        "es-shim-unscopables": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/arraybuffer.prototype.slice": {
@@ -3128,6 +3449,13 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/birecord": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/birecord/-/birecord-0.1.1.tgz",
+      "integrity": "sha512-VUpsf/qykW0heRlC8LooCq28Kxn3mAqKohhDG/49rrsQ1dT1CXyj/pgXS+5BSRzFTR/3DyIBOqQOrGyZOh71Aw==",
+      "dev": true,
+      "license": "(MIT OR Apache-2.0)"
     },
     "node_modules/brace-expansion": {
       "version": "1.1.13",
@@ -3314,6 +3642,13 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
+    },
+    "node_modules/compare-versions": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-6.1.1.tgz",
+      "integrity": "sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -3576,35 +3911,6 @@
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
       "dev": true,
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-iterator-helpers": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/es-iterator-helpers/-/es-iterator-helpers-1.3.1.tgz",
-      "integrity": "sha512-zWwRvqWiuBPr0muUG/78cW3aHROFCNIQ3zpmYDpwdbnt2m+xlNyRWpHBpa2lJjSBit7BQ+RXA1iwbSmu5yJ/EQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.4",
-        "define-properties": "^1.2.1",
-        "es-abstract": "^1.24.1",
-        "es-errors": "^1.3.0",
-        "es-set-tostringtag": "^2.1.0",
-        "function-bind": "^1.1.2",
-        "get-intrinsic": "^1.3.0",
-        "globalthis": "^1.0.4",
-        "gopd": "^1.2.0",
-        "has-property-descriptors": "^1.0.2",
-        "has-proto": "^1.2.0",
-        "has-symbols": "^1.1.0",
-        "internal-slot": "^1.1.0",
-        "iterator.prototype": "^1.1.5",
-        "math-intrinsics": "^1.1.0",
-        "safe-array-concat": "^1.1.3"
-      },
       "engines": {
         "node": ">= 0.4"
       }
@@ -3894,39 +4200,6 @@
         "semver": "bin/semver.js"
       }
     },
-    "node_modules/eslint-plugin-react": {
-      "version": "7.37.5",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.37.5.tgz",
-      "integrity": "sha512-Qteup0SqU15kdocexFNAJMvCJEfa2xUKNV4CC1xsVMrIIqEy3SQ/rqyxCWNzfrd3/ldy6HMlD2e0JDVpDg2qIA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "array-includes": "^3.1.8",
-        "array.prototype.findlast": "^1.2.5",
-        "array.prototype.flatmap": "^1.3.3",
-        "array.prototype.tosorted": "^1.1.4",
-        "doctrine": "^2.1.0",
-        "es-iterator-helpers": "^1.2.1",
-        "estraverse": "^5.3.0",
-        "hasown": "^2.0.2",
-        "jsx-ast-utils": "^2.4.1 || ^3.0.0",
-        "minimatch": "^3.1.2",
-        "object.entries": "^1.1.9",
-        "object.fromentries": "^2.0.8",
-        "object.values": "^1.2.1",
-        "prop-types": "^15.8.1",
-        "resolve": "^2.0.0-next.5",
-        "semver": "^6.3.1",
-        "string.prototype.matchall": "^4.0.12",
-        "string.prototype.repeat": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      },
-      "peerDependencies": {
-        "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7"
-      }
-    },
     "node_modules/eslint-plugin-react-hooks": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.1.1.tgz",
@@ -3944,44 +4217,6 @@
       },
       "peerDependencies": {
         "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0"
-      }
-    },
-    "node_modules/eslint-plugin-react/node_modules/doctrine": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
-      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
-      "dev": true,
-      "dependencies": {
-        "esutils": "^2.0.2"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/eslint-plugin-react/node_modules/resolve": {
-      "version": "2.0.0-next.5",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.5.tgz",
-      "integrity": "sha512-U7WjGVG9sH8tvjW5SmGbQuui75FiyjAX72HX15DwBBwF9dNiQZRQAg9nnPhYy+TUnE0+VcrttuvNI8oSxZcocA==",
-      "dev": true,
-      "dependencies": {
-        "is-core-module": "^2.13.0",
-        "path-parse": "^1.0.7",
-        "supports-preserve-symlinks-flag": "^1.0.0"
-      },
-      "bin": {
-        "resolve": "bin/resolve"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/eslint-plugin-react/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver.js"
       }
     },
     "node_modules/eslint-scope": {
@@ -4486,9 +4721,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "17.4.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-17.4.0.tgz",
-      "integrity": "sha512-hjrNztw/VajQwOLsMNT1cbJiH2muO3OROCHnbehc8eY5JyD2gqz4AcMHPqgaOR59DjgUjYAYLeH699g/eWi2jw==",
+      "version": "17.6.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.6.0.tgz",
+      "integrity": "sha512-sepffkT8stwnIYbsMBpoCHJuJM5l98FUF2AnE07hfvE0m/qp3R586hw4jF4uadbhvg1ooIdzuu7CsfD2jzCaNA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4921,6 +5156,32 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-immutable-type": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/is-immutable-type/-/is-immutable-type-5.0.2.tgz",
+      "integrity": "sha512-liGTvz7pbINOKvy0P4VTCEAIf8xrKJ9165xnwsS7udUyYxwDGBdQIJd+OhwxAn6Kv3pzdy1uha4oJCigzNw2xA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "ko-fi",
+          "url": "https://ko-fi.com/rebeccastevens"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/is-immutable-type"
+        }
+      ],
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@typescript-eslint/type-utils": "^8.0.0",
+        "ts-api-utils": "^2.0.0",
+        "ts-declaration-location": "^1.0.4"
+      },
+      "peerDependencies": {
+        "eslint": "*",
+        "typescript": ">=4.7.4"
+      }
+    },
     "node_modules/is-map": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
@@ -5177,24 +5438,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/iterator.prototype": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/iterator.prototype/-/iterator.prototype-1.1.5.tgz",
-      "integrity": "sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "define-data-property": "^1.1.4",
-        "es-object-atoms": "^1.0.0",
-        "get-intrinsic": "^1.2.6",
-        "get-proto": "^1.0.0",
-        "has-symbols": "^1.1.0",
-        "set-function-name": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -5264,19 +5507,6 @@
       },
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/jsx-ast-utils": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.1.tgz",
-      "integrity": "sha512-pxrjmNpeRw5wwVeWyEAk7QJu2GnBO3uzPFmHCKJJFPKK2Cy0cWL23krGtLdnMmbIi6/FjlrQpPyfQI19ByPOhQ==",
-      "dev": true,
-      "dependencies": {
-        "array-includes": "^3.1.5",
-        "object.assign": "^4.1.2"
-      },
-      "engines": {
-        "node": ">=4.0"
       }
     },
     "node_modules/keyv": {
@@ -5571,18 +5801,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/loose-envify": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
-      "dependencies": {
-        "js-tokens": "^3.0.0 || ^4.0.0"
-      },
-      "bin": {
-        "loose-envify": "cli.js"
-      }
-    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -5689,15 +5907,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/object-assign": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/object-inspect": {
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
@@ -5739,22 +5948,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/object.entries": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.9.tgz",
-      "integrity": "sha512-8u/hfXFRBD1O0hPUjioLhoWFHRmt6tKA4/vZPyckBr18l1KE9uHrFaFaUi8MDRTpi4uak2goyPTSNJLXX2k2Hw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.4",
-        "define-properties": "^1.2.1",
-        "es-object-atoms": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/object.fromentries": {
@@ -6073,17 +6266,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/prop-types": {
-      "version": "15.8.1",
-      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
-      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
-      "dependencies": {
-        "loose-envify": "^1.4.0",
-        "object-assign": "^4.1.1",
-        "react-is": "^16.13.1"
-      }
-    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -6114,12 +6296,6 @@
       "peerDependencies": {
         "react": "^19.2.6"
       }
-    },
-    "node_modules/react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true
     },
     "node_modules/react-refresh": {
       "version": "0.17.0",
@@ -6541,43 +6717,12 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/string.prototype.matchall": {
-      "version": "4.0.12",
-      "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.12.tgz",
-      "integrity": "sha512-6CC9uyBL+/48dYizRf7H7VAYCMCNTBeM78x/VTUe9bFEaxBepPJDa1Ow99LqI/1yF7kuy7Q3cQsYMrcjGUcskA==",
+    "node_modules/string-ts": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/string-ts/-/string-ts-2.3.1.tgz",
+      "integrity": "sha512-xSJq+BS52SaFFAVxuStmx6n5aYZU571uYUnUrPXkPFCfdHyZMMlbP2v2Wx5sNBnAVzq/2+0+mcBLBa3Xa5ubYw==",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.3",
-        "define-properties": "^1.2.1",
-        "es-abstract": "^1.23.6",
-        "es-errors": "^1.3.0",
-        "es-object-atoms": "^1.0.0",
-        "get-intrinsic": "^1.2.6",
-        "gopd": "^1.2.0",
-        "has-symbols": "^1.1.0",
-        "internal-slot": "^1.1.0",
-        "regexp.prototype.flags": "^1.5.3",
-        "set-function-name": "^2.0.2",
-        "side-channel": "^1.1.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/string.prototype.repeat": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/string.prototype.repeat/-/string.prototype.repeat-1.0.0.tgz",
-      "integrity": "sha512-0u/TldDbKD8bFCQ/4f5+mNRrXwZ8hg2w7ZR8wa16e8z9XpePWl3eGEcUD0OXpEH/VJH/2G3gjUtR3ZOiBe2S/w==",
-      "dev": true,
-      "dependencies": {
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.5"
-      }
+      "license": "MIT"
     },
     "node_modules/string.prototype.trim": {
       "version": "1.2.10",
@@ -6763,6 +6908,36 @@
       "peerDependencies": {
         "typescript": ">=4.8.4"
       }
+    },
+    "node_modules/ts-declaration-location": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/ts-declaration-location/-/ts-declaration-location-1.0.7.tgz",
+      "integrity": "sha512-EDyGAwH1gO0Ausm9gV6T2nUvBgXT5kGoCMJPllOaooZ+4VvJiKBdZE7wK18N1deEowhcUptS+5GXZK8U/fvpwA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "ko-fi",
+          "url": "https://ko-fi.com/rebeccastevens"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/ts-declaration-location"
+        }
+      ],
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "picomatch": "^4.0.2"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.0.0"
+      }
+    },
+    "node_modules/ts-pattern": {
+      "version": "5.9.0",
+      "resolved": "https://registry.npmjs.org/ts-pattern/-/ts-pattern-5.9.0.tgz",
+      "integrity": "sha512-6s5V71mX8qBUmlgbrfL33xDUwO0fq48rxAu2LBE11WBeGdpCPOsXksQbZJHvHwhrd3QjUusd3mAOM5Gg0mFBLg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tsconfig-paths": {
       "version": "3.15.0",
@@ -7722,6 +7897,85 @@
       "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
       "dev": true
     },
+    "@eslint-react/ast": {
+      "version": "1.53.1",
+      "resolved": "https://registry.npmjs.org/@eslint-react/ast/-/ast-1.53.1.tgz",
+      "integrity": "sha512-qvUC99ewtriJp9quVEOvZ6+RHcsMLfVQ0OhZ4/LupZUDhjW7GiX1dxJsFaxHdJ9rLNLhQyLSPmbAToeqUrSruQ==",
+      "dev": true,
+      "requires": {
+        "@eslint-react/eff": "1.53.1",
+        "@typescript-eslint/types": "^8.43.0",
+        "@typescript-eslint/typescript-estree": "^8.43.0",
+        "@typescript-eslint/utils": "^8.43.0",
+        "string-ts": "^2.2.1",
+        "ts-pattern": "^5.8.0"
+      }
+    },
+    "@eslint-react/core": {
+      "version": "1.53.1",
+      "resolved": "https://registry.npmjs.org/@eslint-react/core/-/core-1.53.1.tgz",
+      "integrity": "sha512-8prroos5/Uvvh8Tjl1HHCpq4HWD3hV9tYkm7uXgKA6kqj0jHlgRcQzuO6ZPP7feBcK3uOeug7xrq03BuG8QKCA==",
+      "dev": true,
+      "requires": {
+        "@eslint-react/ast": "1.53.1",
+        "@eslint-react/eff": "1.53.1",
+        "@eslint-react/kit": "1.53.1",
+        "@eslint-react/shared": "1.53.1",
+        "@eslint-react/var": "1.53.1",
+        "@typescript-eslint/scope-manager": "^8.43.0",
+        "@typescript-eslint/type-utils": "^8.43.0",
+        "@typescript-eslint/types": "^8.43.0",
+        "@typescript-eslint/utils": "^8.43.0",
+        "birecord": "^0.1.1",
+        "ts-pattern": "^5.8.0"
+      }
+    },
+    "@eslint-react/eff": {
+      "version": "1.53.1",
+      "resolved": "https://registry.npmjs.org/@eslint-react/eff/-/eff-1.53.1.tgz",
+      "integrity": "sha512-uq20lPRAmsWRjIZm+mAV/2kZsU2nDqn5IJslxGWe3Vfdw23hoyhEw3S1KKlxbftwbTvsZjKvVP0iw3bZo/NUpg==",
+      "dev": true
+    },
+    "@eslint-react/kit": {
+      "version": "1.53.1",
+      "resolved": "https://registry.npmjs.org/@eslint-react/kit/-/kit-1.53.1.tgz",
+      "integrity": "sha512-zOi2le9V4rMrJvQV4OeedGvMGvDT46OyFPOwXKs7m0tQu5vXVJ8qwIPaVQT1n/WIuvOg49OfmAVaHpGxK++xLQ==",
+      "dev": true,
+      "requires": {
+        "@eslint-react/eff": "1.53.1",
+        "@typescript-eslint/utils": "^8.43.0",
+        "ts-pattern": "^5.8.0",
+        "zod": "^4.1.5"
+      }
+    },
+    "@eslint-react/shared": {
+      "version": "1.53.1",
+      "resolved": "https://registry.npmjs.org/@eslint-react/shared/-/shared-1.53.1.tgz",
+      "integrity": "sha512-gomJQmFqQgQVI3Ra4vTMG/s6a4bx3JqeNiTBjxBJt4C9iGaBj458GkP4LJHX7TM6xUzX+fMSKOPX7eV3C/+UCw==",
+      "dev": true,
+      "requires": {
+        "@eslint-react/eff": "1.53.1",
+        "@eslint-react/kit": "1.53.1",
+        "@typescript-eslint/utils": "^8.43.0",
+        "ts-pattern": "^5.8.0",
+        "zod": "^4.1.5"
+      }
+    },
+    "@eslint-react/var": {
+      "version": "1.53.1",
+      "resolved": "https://registry.npmjs.org/@eslint-react/var/-/var-1.53.1.tgz",
+      "integrity": "sha512-yzwopvPntcHU7mmDvWzRo1fb8QhjD8eDRRohD11rTV1u7nWO4QbJi0pOyugQakvte1/W11Y0Vr8Of0Ojk/A6zg==",
+      "dev": true,
+      "requires": {
+        "@eslint-react/ast": "1.53.1",
+        "@eslint-react/eff": "1.53.1",
+        "@typescript-eslint/scope-manager": "^8.43.0",
+        "@typescript-eslint/types": "^8.43.0",
+        "@typescript-eslint/utils": "^8.43.0",
+        "string-ts": "^2.2.1",
+        "ts-pattern": "^5.8.0"
+      }
+    },
     "@eslint/config-array": {
       "version": "0.21.2",
       "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
@@ -7864,14 +8118,159 @@
       "dev": true
     },
     "@jchiam/eslint-config": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@jchiam/eslint-config/-/eslint-config-5.0.2.tgz",
-      "integrity": "sha512-sMcpGOwJTC3dyDMJhBrs7sPcwv2EMmZ/qxASO5ZH5QRQ+xq62TIxG2/kq5Z8v46H2FUoAGn+KdrLk2cr6v49YA==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@jchiam/eslint-config/-/eslint-config-5.1.1.tgz",
+      "integrity": "sha512-kph4olazeWKVE4vht7cMdKiSzJ5Lx8aGgPbJxmji6uTZ/zcBPWH6pPIU1KJ0VCw061gpydc8t24xKHW0f1O47g==",
       "dev": true,
       "requires": {
+        "@eslint-react/eslint-plugin": "^1.0.0",
         "@eslint/js": "^9.0.0",
         "@stylistic/eslint-plugin": "^5.0.0",
-        "globals": "^17.0.0"
+        "globals": "^17.6.0"
+      },
+      "dependencies": {
+        "@eslint-react/eslint-plugin": {
+          "version": "1.53.1",
+          "resolved": "https://registry.npmjs.org/@eslint-react/eslint-plugin/-/eslint-plugin-1.53.1.tgz",
+          "integrity": "sha512-JZ2ciXNCC9CtBBAqYtwWH+Jy/7ZzLw+whei8atP4Fxsbh+Scs30MfEwBzuiEbNw6uF9eZFfPidchpr5RaEhqxg==",
+          "dev": true,
+          "requires": {
+            "@eslint-react/eff": "1.53.1",
+            "@eslint-react/kit": "1.53.1",
+            "@eslint-react/shared": "1.53.1",
+            "@typescript-eslint/scope-manager": "^8.43.0",
+            "@typescript-eslint/type-utils": "^8.43.0",
+            "@typescript-eslint/types": "^8.43.0",
+            "@typescript-eslint/utils": "^8.43.0",
+            "eslint-plugin-react-debug": "1.53.1",
+            "eslint-plugin-react-dom": "1.53.1",
+            "eslint-plugin-react-hooks-extra": "1.53.1",
+            "eslint-plugin-react-naming-convention": "1.53.1",
+            "eslint-plugin-react-web-api": "1.53.1",
+            "eslint-plugin-react-x": "1.53.1"
+          }
+        },
+        "eslint-plugin-react-debug": {
+          "version": "1.53.1",
+          "resolved": "https://registry.npmjs.org/eslint-plugin-react-debug/-/eslint-plugin-react-debug-1.53.1.tgz",
+          "integrity": "sha512-WNOiQ6jhodJE88VjBU/IVDM+2Zr9gKHlBFDUSA3fQ0dMB5RiBVj5wMtxbxRuipK/GqNJbteqHcZoYEod7nfddg==",
+          "dev": true,
+          "requires": {
+            "@eslint-react/ast": "1.53.1",
+            "@eslint-react/core": "1.53.1",
+            "@eslint-react/eff": "1.53.1",
+            "@eslint-react/kit": "1.53.1",
+            "@eslint-react/shared": "1.53.1",
+            "@eslint-react/var": "1.53.1",
+            "@typescript-eslint/scope-manager": "^8.43.0",
+            "@typescript-eslint/type-utils": "^8.43.0",
+            "@typescript-eslint/types": "^8.43.0",
+            "@typescript-eslint/utils": "^8.43.0",
+            "string-ts": "^2.2.1",
+            "ts-pattern": "^5.8.0"
+          }
+        },
+        "eslint-plugin-react-dom": {
+          "version": "1.53.1",
+          "resolved": "https://registry.npmjs.org/eslint-plugin-react-dom/-/eslint-plugin-react-dom-1.53.1.tgz",
+          "integrity": "sha512-UYrWJ2cS4HpJ1A5XBuf1HfMpPoLdfGil+27g/ldXfGemb4IXqlxHt4ANLyC8l2CWcE3SXGJW7mTslL34MG0qTQ==",
+          "dev": true,
+          "requires": {
+            "@eslint-react/ast": "1.53.1",
+            "@eslint-react/core": "1.53.1",
+            "@eslint-react/eff": "1.53.1",
+            "@eslint-react/kit": "1.53.1",
+            "@eslint-react/shared": "1.53.1",
+            "@eslint-react/var": "1.53.1",
+            "@typescript-eslint/scope-manager": "^8.43.0",
+            "@typescript-eslint/types": "^8.43.0",
+            "@typescript-eslint/utils": "^8.43.0",
+            "compare-versions": "^6.1.1",
+            "string-ts": "^2.2.1",
+            "ts-pattern": "^5.8.0"
+          }
+        },
+        "eslint-plugin-react-hooks-extra": {
+          "version": "1.53.1",
+          "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks-extra/-/eslint-plugin-react-hooks-extra-1.53.1.tgz",
+          "integrity": "sha512-fshTnMWNn9NjFLIuy7HzkRgGK29vKv4ZBO9UMr+kltVAfKLMeXXP6021qVKk66i/XhQjbktiS+vQsu1Rd3ZKvg==",
+          "dev": true,
+          "requires": {
+            "@eslint-react/ast": "1.53.1",
+            "@eslint-react/core": "1.53.1",
+            "@eslint-react/eff": "1.53.1",
+            "@eslint-react/kit": "1.53.1",
+            "@eslint-react/shared": "1.53.1",
+            "@eslint-react/var": "1.53.1",
+            "@typescript-eslint/scope-manager": "^8.43.0",
+            "@typescript-eslint/type-utils": "^8.43.0",
+            "@typescript-eslint/types": "^8.43.0",
+            "@typescript-eslint/utils": "^8.43.0",
+            "string-ts": "^2.2.1",
+            "ts-pattern": "^5.8.0"
+          }
+        },
+        "eslint-plugin-react-naming-convention": {
+          "version": "1.53.1",
+          "resolved": "https://registry.npmjs.org/eslint-plugin-react-naming-convention/-/eslint-plugin-react-naming-convention-1.53.1.tgz",
+          "integrity": "sha512-rvZ/B/CSVF8d34HQ4qIt90LRuxotVx+KUf3i1OMXAyhsagEFMRe4gAlPJiRufZ+h9lnuu279bEdd+NINsXOteA==",
+          "dev": true,
+          "requires": {
+            "@eslint-react/ast": "1.53.1",
+            "@eslint-react/core": "1.53.1",
+            "@eslint-react/eff": "1.53.1",
+            "@eslint-react/kit": "1.53.1",
+            "@eslint-react/shared": "1.53.1",
+            "@eslint-react/var": "1.53.1",
+            "@typescript-eslint/scope-manager": "^8.43.0",
+            "@typescript-eslint/type-utils": "^8.43.0",
+            "@typescript-eslint/types": "^8.43.0",
+            "@typescript-eslint/utils": "^8.43.0",
+            "string-ts": "^2.2.1",
+            "ts-pattern": "^5.8.0"
+          }
+        },
+        "eslint-plugin-react-web-api": {
+          "version": "1.53.1",
+          "resolved": "https://registry.npmjs.org/eslint-plugin-react-web-api/-/eslint-plugin-react-web-api-1.53.1.tgz",
+          "integrity": "sha512-INVZ3Cbl9/b+sizyb43ChzEPXXYuDsBGU9BIg7OVTNPyDPloCXdI+dQFAcSlDocZhPrLxhPV3eT6+gXbygzYXg==",
+          "dev": true,
+          "requires": {
+            "@eslint-react/ast": "1.53.1",
+            "@eslint-react/core": "1.53.1",
+            "@eslint-react/eff": "1.53.1",
+            "@eslint-react/kit": "1.53.1",
+            "@eslint-react/shared": "1.53.1",
+            "@eslint-react/var": "1.53.1",
+            "@typescript-eslint/scope-manager": "^8.43.0",
+            "@typescript-eslint/types": "^8.43.0",
+            "@typescript-eslint/utils": "^8.43.0",
+            "string-ts": "^2.2.1",
+            "ts-pattern": "^5.8.0"
+          }
+        },
+        "eslint-plugin-react-x": {
+          "version": "1.53.1",
+          "resolved": "https://registry.npmjs.org/eslint-plugin-react-x/-/eslint-plugin-react-x-1.53.1.tgz",
+          "integrity": "sha512-MwMNnVwiPem0U6SlejDF/ddA4h/lmP6imL1RDZ2m3pUBrcdcOwOx0gyiRVTA3ENnhRlWfHljHf5y7m8qDSxMEg==",
+          "dev": true,
+          "requires": {
+            "@eslint-react/ast": "1.53.1",
+            "@eslint-react/core": "1.53.1",
+            "@eslint-react/eff": "1.53.1",
+            "@eslint-react/kit": "1.53.1",
+            "@eslint-react/shared": "1.53.1",
+            "@eslint-react/var": "1.53.1",
+            "@typescript-eslint/scope-manager": "^8.43.0",
+            "@typescript-eslint/type-utils": "^8.43.0",
+            "@typescript-eslint/types": "^8.43.0",
+            "@typescript-eslint/utils": "^8.43.0",
+            "compare-versions": "^6.1.1",
+            "is-immutable-type": "^5.0.1",
+            "string-ts": "^2.2.1",
+            "ts-pattern": "^5.8.0"
+          }
+        }
       }
     },
     "@jridgewell/gen-mapping": {
@@ -8861,20 +9260,6 @@
         "math-intrinsics": "^1.1.0"
       }
     },
-    "array.prototype.findlast": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/array.prototype.findlast/-/array.prototype.findlast-1.2.5.tgz",
-      "integrity": "sha512-CVvd6FHg1Z3POpBLxO6E6zr+rSKEQ9L6rZHAaY7lLfhKsWYUBBOuMs0e9o24oopj6H+geRCX0YJ+TJLBK2eHyQ==",
-      "dev": true,
-      "requires": {
-        "call-bind": "^1.0.7",
-        "define-properties": "^1.2.1",
-        "es-abstract": "^1.23.2",
-        "es-errors": "^1.3.0",
-        "es-object-atoms": "^1.0.0",
-        "es-shim-unscopables": "^1.0.2"
-      }
-    },
     "array.prototype.findlastindex": {
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/array.prototype.findlastindex/-/array.prototype.findlastindex-1.2.6.tgz",
@@ -8911,19 +9296,6 @@
         "call-bind": "^1.0.8",
         "define-properties": "^1.2.1",
         "es-abstract": "^1.23.5",
-        "es-shim-unscopables": "^1.0.2"
-      }
-    },
-    "array.prototype.tosorted": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/array.prototype.tosorted/-/array.prototype.tosorted-1.1.4.tgz",
-      "integrity": "sha512-p6Fx8B7b7ZhL/gmUsAy0D15WhvDccw3mnGNbZpi3pmeJdxtWsj2jEaI4Y6oo3XiHfzuSgPwKc04MYt6KgvC/wA==",
-      "dev": true,
-      "requires": {
-        "call-bind": "^1.0.7",
-        "define-properties": "^1.2.1",
-        "es-abstract": "^1.23.3",
-        "es-errors": "^1.3.0",
         "es-shim-unscopables": "^1.0.2"
       }
     },
@@ -8967,6 +9339,12 @@
       "version": "2.10.13",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.13.tgz",
       "integrity": "sha512-BL2sTuHOdy0YT1lYieUxTw/QMtPBC3pmlJC6xk8BBYVv6vcw3SGdKemQ+Xsx9ik2F/lYDO9tqsFQH1r9PFuHKw==",
+      "dev": true
+    },
+    "birecord": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/birecord/-/birecord-0.1.1.tgz",
+      "integrity": "sha512-VUpsf/qykW0heRlC8LooCq28Kxn3mAqKohhDG/49rrsQ1dT1CXyj/pgXS+5BSRzFTR/3DyIBOqQOrGyZOh71Aw==",
       "dev": true
     },
     "brace-expansion": {
@@ -9071,6 +9449,12 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "compare-versions": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-6.1.1.tgz",
+      "integrity": "sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg==",
       "dev": true
     },
     "concat-map": {
@@ -9268,31 +9652,6 @@
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
       "dev": true
-    },
-    "es-iterator-helpers": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/es-iterator-helpers/-/es-iterator-helpers-1.3.1.tgz",
-      "integrity": "sha512-zWwRvqWiuBPr0muUG/78cW3aHROFCNIQ3zpmYDpwdbnt2m+xlNyRWpHBpa2lJjSBit7BQ+RXA1iwbSmu5yJ/EQ==",
-      "dev": true,
-      "requires": {
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.4",
-        "define-properties": "^1.2.1",
-        "es-abstract": "^1.24.1",
-        "es-errors": "^1.3.0",
-        "es-set-tostringtag": "^2.1.0",
-        "function-bind": "^1.1.2",
-        "get-intrinsic": "^1.3.0",
-        "globalthis": "^1.0.4",
-        "gopd": "^1.2.0",
-        "has-property-descriptors": "^1.0.2",
-        "has-proto": "^1.2.0",
-        "has-symbols": "^1.1.0",
-        "internal-slot": "^1.1.0",
-        "iterator.prototype": "^1.1.5",
-        "math-intrinsics": "^1.1.0",
-        "safe-array-concat": "^1.1.3"
-      }
     },
     "es-object-atoms": {
       "version": "1.1.1",
@@ -9554,60 +9913,6 @@
           "dev": true,
           "requires": {
             "esutils": "^2.0.2"
-          }
-        },
-        "semver": {
-          "version": "6.3.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-          "dev": true
-        }
-      }
-    },
-    "eslint-plugin-react": {
-      "version": "7.37.5",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.37.5.tgz",
-      "integrity": "sha512-Qteup0SqU15kdocexFNAJMvCJEfa2xUKNV4CC1xsVMrIIqEy3SQ/rqyxCWNzfrd3/ldy6HMlD2e0JDVpDg2qIA==",
-      "dev": true,
-      "requires": {
-        "array-includes": "^3.1.8",
-        "array.prototype.findlast": "^1.2.5",
-        "array.prototype.flatmap": "^1.3.3",
-        "array.prototype.tosorted": "^1.1.4",
-        "doctrine": "^2.1.0",
-        "es-iterator-helpers": "^1.2.1",
-        "estraverse": "^5.3.0",
-        "hasown": "^2.0.2",
-        "jsx-ast-utils": "^2.4.1 || ^3.0.0",
-        "minimatch": "^3.1.2",
-        "object.entries": "^1.1.9",
-        "object.fromentries": "^2.0.8",
-        "object.values": "^1.2.1",
-        "prop-types": "^15.8.1",
-        "resolve": "^2.0.0-next.5",
-        "semver": "^6.3.1",
-        "string.prototype.matchall": "^4.0.12",
-        "string.prototype.repeat": "^1.0.0"
-      },
-      "dependencies": {
-        "doctrine": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
-          "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
-          "dev": true,
-          "requires": {
-            "esutils": "^2.0.2"
-          }
-        },
-        "resolve": {
-          "version": "2.0.0-next.5",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.5.tgz",
-          "integrity": "sha512-U7WjGVG9sH8tvjW5SmGbQuui75FiyjAX72HX15DwBBwF9dNiQZRQAg9nnPhYy+TUnE0+VcrttuvNI8oSxZcocA==",
-          "dev": true,
-          "requires": {
-            "is-core-module": "^2.13.0",
-            "path-parse": "^1.0.7",
-            "supports-preserve-symlinks-flag": "^1.0.0"
           }
         },
         "semver": {
@@ -9899,9 +10204,9 @@
       }
     },
     "globals": {
-      "version": "17.4.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-17.4.0.tgz",
-      "integrity": "sha512-hjrNztw/VajQwOLsMNT1cbJiH2muO3OROCHnbehc8eY5JyD2gqz4AcMHPqgaOR59DjgUjYAYLeH699g/eWi2jw==",
+      "version": "17.6.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.6.0.tgz",
+      "integrity": "sha512-sepffkT8stwnIYbsMBpoCHJuJM5l98FUF2AnE07hfvE0m/qp3R586hw4jF4uadbhvg1ooIdzuu7CsfD2jzCaNA==",
       "dev": true
     },
     "globalthis": {
@@ -10159,6 +10464,17 @@
         "is-extglob": "^2.1.1"
       }
     },
+    "is-immutable-type": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/is-immutable-type/-/is-immutable-type-5.0.2.tgz",
+      "integrity": "sha512-liGTvz7pbINOKvy0P4VTCEAIf8xrKJ9165xnwsS7udUyYxwDGBdQIJd+OhwxAn6Kv3pzdy1uha4oJCigzNw2xA==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/type-utils": "^8.0.0",
+        "ts-api-utils": "^2.0.0",
+        "ts-declaration-location": "^1.0.4"
+      }
+    },
     "is-map": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
@@ -10315,20 +10631,6 @@
         "istanbul-lib-report": "^3.0.0"
       }
     },
-    "iterator.prototype": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/iterator.prototype/-/iterator.prototype-1.1.5.tgz",
-      "integrity": "sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==",
-      "dev": true,
-      "requires": {
-        "define-data-property": "^1.1.4",
-        "es-object-atoms": "^1.0.0",
-        "get-intrinsic": "^1.2.6",
-        "get-proto": "^1.0.0",
-        "has-symbols": "^1.1.0",
-        "set-function-name": "^2.0.2"
-      }
-    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -10381,16 +10683,6 @@
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
       "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "dev": true
-    },
-    "jsx-ast-utils": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.1.tgz",
-      "integrity": "sha512-pxrjmNpeRw5wwVeWyEAk7QJu2GnBO3uzPFmHCKJJFPKK2Cy0cWL23krGtLdnMmbIi6/FjlrQpPyfQI19ByPOhQ==",
-      "dev": true,
-      "requires": {
-        "array-includes": "^3.1.5",
-        "object.assign": "^4.1.2"
-      }
     },
     "keyv": {
       "version": "4.5.4",
@@ -10523,15 +10815,6 @@
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
     },
-    "loose-envify": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
-      "requires": {
-        "js-tokens": "^3.0.0 || ^4.0.0"
-      }
-    },
     "lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -10601,12 +10884,6 @@
       "integrity": "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==",
       "dev": true
     },
-    "object-assign": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-      "dev": true
-    },
     "object-inspect": {
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
@@ -10631,18 +10908,6 @@
         "es-object-atoms": "^1.0.0",
         "has-symbols": "^1.1.0",
         "object-keys": "^1.1.1"
-      }
-    },
-    "object.entries": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.9.tgz",
-      "integrity": "sha512-8u/hfXFRBD1O0hPUjioLhoWFHRmt6tKA4/vZPyckBr18l1KE9uHrFaFaUi8MDRTpi4uak2goyPTSNJLXX2k2Hw==",
-      "dev": true,
-      "requires": {
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.4",
-        "define-properties": "^1.2.1",
-        "es-object-atoms": "^1.1.1"
       }
     },
     "object.fromentries": {
@@ -10845,17 +11110,6 @@
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
       "dev": true
     },
-    "prop-types": {
-      "version": "15.8.1",
-      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
-      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
-      "requires": {
-        "loose-envify": "^1.4.0",
-        "object-assign": "^4.1.1",
-        "react-is": "^16.13.1"
-      }
-    },
     "punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -10876,12 +11130,6 @@
       "requires": {
         "scheduler": "^0.27.0"
       }
-    },
-    "react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true
     },
     "react-refresh": {
       "version": "0.17.0",
@@ -11170,36 +11418,11 @@
         "internal-slot": "^1.1.0"
       }
     },
-    "string.prototype.matchall": {
-      "version": "4.0.12",
-      "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.12.tgz",
-      "integrity": "sha512-6CC9uyBL+/48dYizRf7H7VAYCMCNTBeM78x/VTUe9bFEaxBepPJDa1Ow99LqI/1yF7kuy7Q3cQsYMrcjGUcskA==",
-      "dev": true,
-      "requires": {
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.3",
-        "define-properties": "^1.2.1",
-        "es-abstract": "^1.23.6",
-        "es-errors": "^1.3.0",
-        "es-object-atoms": "^1.0.0",
-        "get-intrinsic": "^1.2.6",
-        "gopd": "^1.2.0",
-        "has-symbols": "^1.1.0",
-        "internal-slot": "^1.1.0",
-        "regexp.prototype.flags": "^1.5.3",
-        "set-function-name": "^2.0.2",
-        "side-channel": "^1.1.0"
-      }
-    },
-    "string.prototype.repeat": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/string.prototype.repeat/-/string.prototype.repeat-1.0.0.tgz",
-      "integrity": "sha512-0u/TldDbKD8bFCQ/4f5+mNRrXwZ8hg2w7ZR8wa16e8z9XpePWl3eGEcUD0OXpEH/VJH/2G3gjUtR3ZOiBe2S/w==",
-      "dev": true,
-      "requires": {
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.5"
-      }
+    "string-ts": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/string-ts/-/string-ts-2.3.1.tgz",
+      "integrity": "sha512-xSJq+BS52SaFFAVxuStmx6n5aYZU571uYUnUrPXkPFCfdHyZMMlbP2v2Wx5sNBnAVzq/2+0+mcBLBa3Xa5ubYw==",
+      "dev": true
     },
     "string.prototype.trim": {
       "version": "1.2.10",
@@ -11319,6 +11542,21 @@
       "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
       "dev": true,
       "requires": {}
+    },
+    "ts-declaration-location": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/ts-declaration-location/-/ts-declaration-location-1.0.7.tgz",
+      "integrity": "sha512-EDyGAwH1gO0Ausm9gV6T2nUvBgXT5kGoCMJPllOaooZ+4VvJiKBdZE7wK18N1deEowhcUptS+5GXZK8U/fvpwA==",
+      "dev": true,
+      "requires": {
+        "picomatch": "^4.0.2"
+      }
+    },
+    "ts-pattern": {
+      "version": "5.9.0",
+      "resolved": "https://registry.npmjs.org/ts-pattern/-/ts-pattern-5.9.0.tgz",
+      "integrity": "sha512-6s5V71mX8qBUmlgbrfL33xDUwO0fq48rxAu2LBE11WBeGdpCPOsXksQbZJHvHwhrd3QjUusd3mAOM5Gg0mFBLg==",
+      "dev": true
     },
     "tsconfig-paths": {
       "version": "3.15.0",

--- a/package.json
+++ b/package.json
@@ -36,13 +36,12 @@
     "LICENSE"
   ],
   "devDependencies": {
-    "@jchiam/eslint-config": "^5.0.2",
+    "@jchiam/eslint-config": "^5.1.1",
     "@playwright/experimental-ct-react": "^1.59.1",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "eslint": "^9.39.4",
     "eslint-plugin-import": "^2.32.0",
-    "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^7.0.0",
     "husky": "^9.1.7",
     "is-ci": "^4.1.0",


### PR DESCRIPTION
## Summary
- Replace `eslint-plugin-react` with `@eslint-react/eslint-plugin` (via `@jchiam/eslint-config@5.1.1`)
- Disable `@eslint-react/no-forward-ref` rule — `forwardRef` still required for React 18 compatibility
- Bump `@jchiam/eslint-config` from `^5.0.2` to `^5.1.1`

## Test plan
- [ ] `npm run lint` passes with no errors
- [ ] All 16 Playwright tests pass with 100% coverage

Generated with Claude Code