### PR TITLE
ci: bump codecov-action v6 to v7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
       run: npm test
     - name: Post Coverage
       if: matrix.react == '19' && matrix.node == '24'
-      uses: codecov/codecov-action@v6
+      uses: codecov/codecov-action@v7
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: coverage/lcov.info


### PR DESCRIPTION
## Summary
- Bump `codecov/codecov-action` from `v6` to `v7` in `.github/workflows/ci.yml`.
- v6.0.1...v7.0.0 diff is minimal: GPG signing key migration (`codecovsecurity` → `codecovsecops`, same original key), removal of internal Enforce License Compliance workflow, uploader wrapper bump. No input/output schema changes — `token` and `files` remain compatible.

## Test plan
- [ ] CI passes on this PR
- [ ] `Post Coverage` step succeeds for `test (React 19, Node 24)` matrix entry
- [ ] Coverage report appears on Codecov for the PR head commit