### PR TITLE
fix: silence no-forward-ref lint warning + repair lock drift

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1057,6 +1057,22 @@
         }
       }
     },
+    "node_modules/@jchiam/eslint-config/node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",

--- a/src/Checkbox.tsx
+++ b/src/Checkbox.tsx
@@ -1,19 +1,20 @@
-import { ChangeEvent, ComponentPropsWithoutRef, Ref, useCallback } from 'react';
+import { ChangeEvent, ComponentPropsWithoutRef, forwardRef, useCallback } from 'react';
 
 export interface CheckboxProps extends Omit<ComponentPropsWithoutRef<'input'>, 'type' | 'checked' | 'onChange' | 'readOnly'> {
   checked: boolean;
   indeterminate?: boolean;
   onChange?: (e: ChangeEvent<HTMLInputElement>) => void;
-  ref?: Ref<HTMLInputElement>;
 }
 
-const Checkbox = ({
+// forwardRef is still required to forward refs under React 18, which this
+// package supports (peerDependencies: react "18 || 19").
+// eslint-disable-next-line @eslint-react/no-forward-ref
+const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(({
   checked,
   indeterminate = false,
   onChange,
-  ref: forwardedRef,
   ...rest
-}: CheckboxProps) => {
+}, forwardedRef) => {
   const ref = useCallback((input: HTMLInputElement | null) => {
     if (input) input.indeterminate = indeterminate;
     if (typeof forwardedRef === 'function') forwardedRef(input);
@@ -30,7 +31,7 @@ const Checkbox = ({
       onChange={onChange}
     />
   );
-};
+});
 
 Checkbox.displayName = 'Checkbox';
 

--- a/src/Checkbox.tsx
+++ b/src/Checkbox.tsx
@@ -1,17 +1,19 @@
-import { ChangeEvent, ComponentPropsWithoutRef, forwardRef, useCallback } from 'react';
+import { ChangeEvent, ComponentPropsWithoutRef, Ref, useCallback } from 'react';
 
 export interface CheckboxProps extends Omit<ComponentPropsWithoutRef<'input'>, 'type' | 'checked' | 'onChange' | 'readOnly'> {
   checked: boolean;
   indeterminate?: boolean;
   onChange?: (e: ChangeEvent<HTMLInputElement>) => void;
+  ref?: Ref<HTMLInputElement>;
 }
 
-const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(({
+const Checkbox = ({
   checked,
   indeterminate = false,
   onChange,
+  ref: forwardedRef,
   ...rest
-}, forwardedRef) => {
+}: CheckboxProps) => {
   const ref = useCallback((input: HTMLInputElement | null) => {
     if (input) input.indeterminate = indeterminate;
     if (typeof forwardedRef === 'function') forwardedRef(input);
@@ -28,7 +30,7 @@ const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(({
       onChange={onChange}
     />
   );
-});
+};
 
 Checkbox.displayName = 'Checkbox';
 


### PR DESCRIPTION
## Summary
- Keep `forwardRef` in `src/Checkbox.tsx` (required for ref forwarding under React 18, which the package still supports — peer `react: "18 || 19"`) and suppress the `@eslint-react/no-forward-ref` warning with a justifying comment. Dropping `forwardRef` broke the React 18 ref-forwarding tests.
- Restore the nested `optional`/`peer` `typescript@5.9.3` entry in `package-lock.json` that local npm 11 strips but CI''s npm 10 requires, which was breaking `npm ci`.

## Test plan
- [x] `npm run lint` — clean, `no-forward-ref` warning gone
- [x] `npx npm@10 ci --dry-run` — in sync, no EUSAGE
- [x] CI green across the React 18 + 19 / Node 22 + 24 matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)