### PR TITLE
refactor(test): consolidate coverage pipeline into one module

### DIFF
--- a/playwright/teardown.ts
+++ b/playwright/teardown.ts
@@ -1,22 +1,7 @@
-import { existsSync, readdirSync, readFileSync } from 'fs';
-import { join } from 'path';
-import libCoverage from 'istanbul-lib-coverage';
-import libReport from 'istanbul-lib-report';
-import reports from 'istanbul-reports';
+import { mergeCoverageReports } from '../tests/coverage';
 
-async function globalTeardown() {
-  if (!existsSync('.nyc_output')) return;
-
-  const coverageMap = libCoverage.createCoverageMap({});
-
-  for (const file of readdirSync('.nyc_output').filter(f => f.endsWith('.json'))) {
-    const data = JSON.parse(readFileSync(join('.nyc_output', file), 'utf-8'));
-    coverageMap.merge(data);
-  }
-
-  const context = libReport.createContext({ dir: 'coverage', coverageMap });
-  reports.create('lcov').execute(context);
-  reports.create('text').execute(context);
+function globalTeardown() {
+  mergeCoverageReports();
 }
 
 export default globalTeardown;

--- a/tests/coverage.ts
+++ b/tests/coverage.ts
@@ -1,0 +1,42 @@
+import type { Page } from 'playwright-core';
+import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import libCoverage from 'istanbul-lib-coverage';
+import libReport from 'istanbul-lib-report';
+import reports from 'istanbul-reports';
+
+// The seam for the whole coverage pipeline. Both the per-test fixture and the
+// global teardown go through this module, so the .nyc_output contract and the
+// window.__coverage__ global (set by vite-plugin-istanbul) are written down
+// exactly once each. The only firing points left outside are the istanbul
+// instrument step in playwright-ct.config.mjs and the `rm -rf .nyc_output` in
+// package.json's test script — neither can import this module.
+const OUTPUT_DIR = '.nyc_output';
+const REPORT_DIR = 'coverage';
+
+// Pull window.__coverage__ off the page and persist it as one file per test,
+// for the global teardown to merge. No-op when instrumentation is absent.
+export async function dumpCoverage(page: Page): Promise<void> {
+  const coverage = await page.evaluate(
+    () => (window as Window & { __coverage__?: unknown }).__coverage__ ?? null,
+  );
+  if (!coverage) return;
+
+  mkdirSync(OUTPUT_DIR, { recursive: true });
+  const filename = `coverage-${Date.now()}-${Math.random().toString(36).slice(2)}.json`;
+  writeFileSync(join(OUTPUT_DIR, filename), JSON.stringify(coverage));
+}
+
+// Merge every per-test dump into one coverage map and emit lcov + text reports.
+export function mergeCoverageReports(): void {
+  if (!existsSync(OUTPUT_DIR)) return;
+
+  const coverageMap = libCoverage.createCoverageMap({});
+  for (const file of readdirSync(OUTPUT_DIR).filter((f) => f.endsWith('.json'))) {
+    coverageMap.merge(JSON.parse(readFileSync(join(OUTPUT_DIR, file), 'utf-8')));
+  }
+
+  const context = libReport.createContext({ dir: REPORT_DIR, coverageMap });
+  reports.create('lcov').execute(context);
+  reports.create('text').execute(context);
+}

--- a/tests/fixtures.ts
+++ b/tests/fixtures.ts
@@ -1,16 +1,10 @@
 import { test as ctTest, expect } from '@playwright/experimental-ct-react';
-import { mkdirSync, writeFileSync } from 'fs';
-import { join } from 'path';
+import { dumpCoverage } from './coverage';
 
 export const test = ctTest.extend<{ collectCoverage: void }>({
   collectCoverage: [async ({ page }, use) => {
     await use();
-    const coverage = await page.evaluate(() => (window as Window & { __coverage__?: unknown }).__coverage__ ?? null);
-    if (coverage) {
-      mkdirSync('.nyc_output', { recursive: true });
-      const filename = `coverage-${Date.now()}-${Math.random().toString(36).slice(2)}.json`;
-      writeFileSync(join('.nyc_output', filename), JSON.stringify(coverage));
-    }
+    await dumpCoverage(page);
   }, { auto: true }],
 });
 


### PR DESCRIPTION
## Summary
- Add `tests/coverage.ts` as the single seam for the coverage pipeline, owning the `.nyc_output` directory contract, the `window.__coverage__` read, the per-test filename scheme, and the istanbul lcov/text report wiring.
- Rewire `tests/fixtures.ts` to call `dumpCoverage(page)` — the `page.evaluate` read now lives behind the module.
- Rewire `playwright/teardown.ts` to call `mergeCoverageReports()`.
- `.nyc_output` is now named twice instead of three times; the remaining mention is `rm -rf .nyc_output` in package.json (an npm script that cannot import TS), which stays outside the seam by necessity.
- Behavior-preserving: no change to what gets collected or reported.

## Test plan
- [x] `playwright test --config=playwright-ct.config.mjs` — 16 passed
- [x] Coverage holds at 100% for `src/Checkbox.tsx`
- [x] `coverage/lcov.info` still emitted and references `src/Checkbox.tsx`
- [x] `eslint ./src` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)